### PR TITLE
Build and publish native Linux ARM64 bpy wheels

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -100,6 +100,16 @@ jobs:
     permissions:
       contents: write
 
+  build-for-linux-arm64:
+    needs: [check-version]
+    if: ${{ needs.check-version.outputs.tag_input != '' }}
+    uses: ./.github/workflows/build_linux_arm64.yml
+    with:
+      tag: ${{ needs.check-version.outputs.tag_input }}
+      python_version: ${{ needs.check-version.outputs.python_version }}
+    permissions:
+      contents: write
+
   build-for-macos:
     needs: [check-version]
     if: ${{ needs.check-version.outputs.tag_input != '' }}  

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -123,7 +123,12 @@ jobs:
 
   update-versions:
     runs-on: ubuntu-latest
-    needs: [ check-version, build-for-windows, build-for-linux, build-for-macos] 
+    needs:
+      - check-version
+      - build-for-windows
+      - build-for-linux
+      - build-for-linux-arm64
+      - build-for-macos
     if: ${{ needs.check-version.outputs.new_tag == 'true' || needs.check-version.outputs.new_commit == 'true' }}
     permissions:
       contents: write

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -142,13 +142,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit and push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: EndBug/add-and-commit@v7
-        with:
-          default_author: github_actions
-          message: 'Update version info with latest tag and commit'
-          add: 'workspace/version_info.json'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- workspace/version_info.json
+          if git diff --cached --quiet; then
+            echo "No version metadata changes to publish"
+          else
+            git commit -m "Update version info with latest tag and commit"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
+          fi
 
   update-repository-index:
     needs: [update-versions]

--- a/.github/workflows/build_linux_arm64.yml
+++ b/.github/workflows/build_linux_arm64.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 360
     env:
-      TAG: ${{ inputs.tag }}
-      PYTHON_VERSION: ${{ inputs.python_version }}
+      TAG: ${{ inputs.tag || github.event.inputs.tag }}
+      PYTHON_VERSION: ${{ inputs.python_version || github.event.inputs.python_version }}
       CMAKE_BUILD_PARALLEL_LEVEL: "4"
       MAKEFLAGS: "-j4"
       NPROCS: "4"
@@ -99,7 +99,8 @@ jobs:
           wheels = list((Path.home() / ".buildbpy/build_linux_bpy/bin").glob("bpy-*.whl"))
           assert len(wheels) == 1, wheels
           wheel = wheels[0]
-          assert "cp313" in wheel.name, wheel.name
+          expected_abi = "cp" + "".join(os.environ["PYTHON_VERSION"].split(".")[:2])
+          assert f"-{expected_abi}-{expected_abi}-" in wheel.name, wheel.name
           assert "aarch64" in wheel.name, wheel.name
           assert platform.machine().lower() in {"aarch64", "arm64"}
           expected_version = tuple(map(int, os.environ["TAG"].removeprefix("v").split(".")))
@@ -200,6 +201,6 @@ jobs:
       - name: Upload ARM64 wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bpy-${{ env.TAG }}-cp313-linux-aarch64
+          name: bpy-${{ env.TAG }}-python${{ env.PYTHON_VERSION }}-linux-aarch64
           path: ~/.buildbpy/build_linux_bpy/bin/bpy-*.whl
           if-no-files-found: error

--- a/.github/workflows/build_linux_arm64.yml
+++ b/.github/workflows/build_linux_arm64.yml
@@ -78,7 +78,7 @@ jobs:
           path: |
             ~/.buildbpy/build_linux/deps_arm64
             ~/.buildbpy/blender/lib/linux_arm64
-          key: blender-${{ env.TAG }}-linux-arm64-deps-v1
+          key: blender-${{ env.TAG }}-${{ env.PYTHON_VERSION }}-linux-arm64-deps-v1
 
       - name: Build and publish bpy
         env:

--- a/.github/workflows/build_linux_arm64.yml
+++ b/.github/workflows/build_linux_arm64.yml
@@ -124,7 +124,33 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             ~/.buildbpy/build_linux_bpy/bin/bpy-*.whl
 
+      - name: Check existing ARM64 dependency release
+        id: deps_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${TAG#v}"
+          RELEASE_TAG="deps-blender-${VERSION}-linux-arm64-v1"
+          ARCHIVE="blender-${VERSION}-linux-arm64-ubuntu24.04-gcc13-v1.tar.zst"
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            ASSETS="$(gh release view "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json assets \
+              --jq '.assets[].name')"
+            for REQUIRED in "${ARCHIVE}" "${ARCHIVE}.manifest.json" "${ARCHIVE}.sha256"; do
+              if ! grep -Fxq "${REQUIRED}" <<<"${ASSETS}"; then
+                echo "Existing immutable release is incomplete: missing ${REQUIRED}" >&2
+                exit 1
+              fi
+            done
+            echo "Reusing complete immutable dependency release ${RELEASE_TAG}"
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Package verified ARM64 dependency bundle
+        if: steps.deps_release.outputs.exists != 'true'
         run: |
           python - <<'PY'
           import os
@@ -152,15 +178,12 @@ jobs:
           PY
 
       - name: Publish verified ARM64 dependency bundle
+        if: steps.deps_release.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${TAG#v}"
           RELEASE_TAG="deps-blender-${VERSION}-linux-arm64-v1"
-          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "Release ${RELEASE_TAG} already exists and is immutable" >&2
-            exit 1
-          fi
           gh release create "${RELEASE_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \

--- a/.github/workflows/build_linux_arm64.yml
+++ b/.github/workflows/build_linux_arm64.yml
@@ -1,309 +1,108 @@
-name: Build bpy for Linux Arm
+name: Build bpy for Linux ARM64
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Blender Tag to build'
-        required: true
-        default: 'v4.3.2'
-      python_version:
-        description: 'Python version to use'
-        required: true
-        default: '3.11.9'
-  
   workflow_call:
     inputs:
       tag:
-        description: 'Blender Tag to build'
+        description: Blender version tag (for example v5.2.0)
         required: true
         type: string
       python_version:
-        description: 'Python version to use'
+        description: CPython version used by Blender
         required: true
-        default: '3.10.11'
         type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Blender version tag
+        required: true
+        default: v5.2.0
+        type: string
+      python_version:
+        description: CPython version used by Blender
+        required: true
+        default: 3.13.11
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: write
+    timeout-minutes: 360
+    env:
+      TAG: ${{ inputs.tag }}
+      PYTHON_VERSION: ${{ inputs.python_version }}
+      CMAKE_BUILD_PARALLEL_LEVEL: "4"
+      MAKEFLAGS: "-j4"
+
     steps:
-      - name: checkout repo
-        uses: actions/checkout@v4
-        
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
 
-      - name: Set environment variables
-        id: set_env
-        run: |
-          TAG=${{ inputs.tag || github.event.inputs.tag }}
-          PYTHON_VERSION=${{ inputs.python_version || github.event.inputs.python_version }}
-          echo "TAG=$TAG" >> $GITHUB_ENV
-          echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
-
-      # - name: Checkout Blender repository recursively
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: blender/blender
-      #     ref:  ${{ env.TAG }} # Checkout the tag specified in the workflow dispatch
-      #     submodules: 'recursive' # Recursively checkout submodules
-      #     path: blender 
-
-      # - name: Set up Conda
-      #   uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     auto-update-conda: true
-      #     python-version:  ${{ env.PYTHON_VERSION }}
-      #     # environment-file: environment.yml
-      #     activate-environment: bpy-env
-      #     channels: conda-forge
-
-      # - name: Install Conda Dependencies
-      #   run: |
-      #     conda install -y cuda-toolkit setuptools -c "nvidia/label/cuda-12.3.1" -c conda-forge
-      #     # find / -name nvcc
-
-      # - name: Add conda NVCC subdirectories to PATH
-      #   run: |
-      #     # for dir in $(find /home/runner/conda_pkgs_dir/ -mindepth 1 -type d -name *nvcc*); do
-      #     #   echo "$dir" >> $GITHUB_PATH
-      #     #   echo "$dir"
-
-      #     # done
-      #     echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
-
-
-      - name: Check GCC version
-        run: gcc --version
-
-      - name: Install GCC 12
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-12 g++-12
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
-
-      - name: Export GCC 12
-        run: |
-            echo "CC=/usr/bin/gcc-12" >> $GITHUB_ENV
-            echo "CXX=/usr/bin/g++-12" >> $GITHUB_ENV
-      
-      - name: Check GCC version
-        run: gcc --version
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
 
-      # - name: Setup terminal session
-      #   uses: fawazahmed0/action-debug@main
-      #   with:
-      #       credentials: "user:p@ss!"
-
-
-
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-      #   with:
-      #     ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-      #     limit-access-to-actor: true
-      #     ## limits ssh access and adds the ssh public keys of the listed GitHub users
-      #     limit-access-to-users: michaelgold 
-
-      # - name: Cache Blender dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ./lib
-      #     key: ${{ runner.os }}-blender-lib-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-blender-lib-
-
-      - name: Install Linux Dependencies
+      - name: Install system build dependencies
         run: |
-          sudo apt update
-          sudo apt install -y build-essential git git-lfs subversion cmake libx11-dev libxxf86vm-dev libxcursor-dev libxi-dev libxrandr-dev libxinerama-dev libegl-dev
-          sudo apt install -y libwayland-dev wayland-protocols libxkbcommon-dev libdbus-1-dev linux-libc-dev
-          echo "Running install_linux_packages.py"
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential git git-lfs subversion cmake ninja-build \
+            autoconf automake bison libtool meson nasm yasm patchelf \
+            libx11-dev libxxf86vm-dev libxcursor-dev libxi-dev \
+            libxrandr-dev libxinerama-dev libxext-dev libegl-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev \
+            libdbus-1-dev linux-libc-dev libssl-dev libffi-dev \
+            libreadline-dev libbz2-dev liblzma-dev zlib1g-dev \
+            libsqlite3-dev
+          git lfs install --skip-repo
 
-      
-      # - name: Verify X11 Installation
-      #   run: |
-      #     dpkg -l | grep libx11-dev
-
-      # - name: Set Environment Variables for X11
-      #   run: |
-      #     echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-
-      # - name: Unset Miniconda from LD_LIBRARY_PATH
-      #   run: |
-      #     export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | sed 's|:/usr/share/miniconda/lib||')
-
-
-      # - name: Download blender precompiled libraries
-      #   run: |
-      #     if [ ! -d "./lib" ]; then
-      #       mkdir ./lib
-      #       cd ./lib
-      #       svn checkout https://svn.blender.org/svnroot/bf-blender/trunk/lib/linux_x86_64_glibc_228
-      #     fi
-          
-      # - name: Install Cuda Toolkit
-      #   uses: Jimver/cuda-toolkit@v0.2.11
-      #   id: cuda-toolkit
-      #   with:
-      #     cuda: '12.1.0'
-
-
-      # - name: Cache build files (for testing only)
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ./build_linux_bpy
-      #     key: ${{ runner.os }}-blender-build-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-blender-build-
-
-
-      - name: Extract Blender Major Version Number
-        id: version_extraction
+      - name: Install buildbpy
         run: |
-          python -c "import sys; version_tag = sys.argv[1].lstrip('v'); parts = version_tag.split('.'); major_version = '.'.join(parts[:2]); print(f'MAJOR_VERSION={major_version}')" "${{ env.TAG }}" >> $GITHUB_ENV
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -e .
 
-      # - name: Download Precompiled Binaries for the release
-      #   run: |
-      #     mkdir ./lib
-      #     cd ./lib
-      #     svn checkout https://svn.blender.org/svnroot/bf-blender/tags/blender-${{ env.MAJOR_VERSION }}-release/lib/linux_x86_64_glibc_228/
+      - name: Cache native Blender ARM64 dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.buildbpy/lib
+          key: blender-${{ env.TAG }}-linux-arm64-deps-v1
 
-
-      # # - name: Download Blender Python API Stubs
-      # #   id: download-artifact
-      # #   uses: dawidd6/action-download-artifact@v2
-      # #   with:
-      # #     workflow: build_all.yml
-      # #     # github_token: ${{secrets.GITHUB_TOKEN}}
-      # #     name: blender-python-api-stubs-${{ env.TAG }}
-      # #     path: ./build_linux_bpy/bin/
-
-      # - name: Download Blender Python API Stubs
-      #   id: download-artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: blender-python-api-stubs-${{ env.TAG }}
-      #     path: ./build_linux_bpy/bin/
-      
-
-
-      # - name: Build Blender
-      #   run: |
-      #     echo "Building bpy for Linux with tag ${{ env.TAG }}"
-      #     cd ./blender
-      #     make update
-      #     make bpy
-      #     # make bpy VERBOSE=1
-
-      - name: Install Python Dependencies
-        run: |
-          pip install -r ./requirements.txt
-    
-      - name: Update Python
-        run: |
-          pip install -U pip setuptools wheel
-
-      # - name: Free up disk space
-      #   run: |
-      #       echo "Freeing up disk space"
-      #       echo "initial disk space"
-      #       df -h
-      #       # Only remove specific packages we know we don't need
-      #       sudo apt-get remove -y '^dotnet.*' 'php.*' 'mongodb.*' '^google.*' azure-cli \
-      #         powershell 'mysql.*' 'postgres.*' 'ghc.*' '^mongodb.*' '^microsoft.*' \
-      #         '^google-cloud.*' 'firefox' 'android.*' 'azure.*'
-      #       # Clean package cache but don't remove dependencies
-      #       sudo apt-get clean
-      #       # Remove specific directories we know are safe to remove
-      #       sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
-      #       sudo rm -rf /usr/local/lib/node_modules
-      #       rm -rf ~/.cache/pip
-      #       echo "final disk space"
-      #       df -h
-             
-
-      - name: Build Blender
-        run: |
-          python -m src.buildbpy.main --tag ${{ env.TAG }} --install --publish
+      - name: Build and publish bpy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Install compatible numpy version
         run: |
-          pip install "numpy<2.0"
-  
-      - name: Test bpy and numpy import
+          python -m buildbpy.main \
+            --tag "${TAG}" \
+            --install \
+            --publish
+
+      - name: Verify wheel architecture and import
         run: |
-          python -c '
-          import sys, traceback
-          try:
-              import numpy
-              import bpy
-              print("Imported bpy:", bpy.app.version)
-          except Exception:
-              traceback.print_exc()
-              sys.exit(1)
-          '
+          python - <<'PY'
+          from pathlib import Path
+          import platform
+          import bpy
 
-      # - name: Install Blender
-      #   run: python -c "import shutil, site; shutil.copytree('./build_linux_bpy/bin/bpy', site.getsitepackages()[0] + '/bpy')"
+          wheels = list((Path.home() / ".buildbpy/build_linux_bpy/bin").glob("bpy-*.whl"))
+          assert len(wheels) == 1, wheels
+          wheel = wheels[0]
+          assert "cp313" in wheel.name, wheel.name
+          assert "aarch64" in wheel.name, wheel.name
+          assert platform.machine().lower() in {"aarch64", "arm64"}
+          assert bpy.app.version[:2] == (5, 2), bpy.app.version
+          print(f"wheel={wheel}")
+          print(f"architecture={platform.machine()}")
+          print(f"bpy_version={bpy.app.version_string}")
+          PY
 
-
-      # - name: Install docs prereqs
-      #   run: |
-      #     pip install bpystubgen
-
-      # - name: Generate Api Docs and stubs
-      #   run: |
-      #     cd ./blender
-      #     python ./doc/python_api/sphinx_doc_gen.py -- --output=../python_api
-      #     python -m bpystubgen ../python_api/sphinx-in ../python_api/output
-
-      # - name: Copy BPY Stubs to bin folder
-      #   run: |
-      #     cp -R ./python_api/output/*  ./build_linux_bpy/bin/
-
-
-      # - name: Setup terminal session
-      #   uses: fawazahmed0/action-debug@main
-      #   with:
-      #       credentials: "user:p@ss!"
-
-
-      # - name: Make Wheel
-      #   run: |
-      #     # PYTHON3=$(which python3)
-      #     # PYTHON=$(which python)
-          
-      #     # sudo rm $PYTHON3 
-      #     # ln -s $PYTHON $PYTHON3
-      #     pip install -U pip setuptools wheel
-      #     cp ./workspace/make_bpy_wheel.py ./blender/build_files/utils/
-      #     python ./blender/build_files/utils/make_bpy_wheel.py ./build_linux_bpy/bin/
-
-      # - name: Upload Wheel as Artifact
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: bpy-linux
-      #     path: |
-      #       ./build_linux_bpy/bin/*.whl
-
-      # - name: Install Dependencies
-      #   run: |
-      #     python -m pip install --upgrade pip ndg-httpsclient pyopenssl pyasn1
-      #     python -m pip install bpystubgen requests python-dotenv typer=='0.9.0' httpx
-
-      # - name: Publish Wheel
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: python workspace/build_blender.py publish-github  ${{ env.TAG }} ./build_linux_bpy/bin
+      - name: Upload ARM64 wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bpy-${{ env.TAG }}-cp313-linux-aarch64
+          path: ~/.buildbpy/build_linux_bpy/bin/bpy-*.whl
+          if-no-files-found: error

--- a/.github/workflows/build_linux_arm64.yml
+++ b/.github/workflows/build_linux_arm64.yml
@@ -36,6 +36,7 @@ jobs:
       PYTHON_VERSION: ${{ inputs.python_version }}
       CMAKE_BUILD_PARALLEL_LEVEL: "4"
       MAKEFLAGS: "-j4"
+      NPROCS: "4"
 
     steps:
       - uses: actions/checkout@v4
@@ -51,12 +52,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential git git-lfs subversion cmake ninja-build \
-            autoconf automake bison libtool meson nasm yasm patchelf \
+            build-essential gcc-14 g++-14 git git-lfs subversion cmake ninja-build zstd \
+            autoconf automake autopoint bison flex gettext help2man libtool \
+            meson nasm yasm patchelf pkg-config python3-mako tcl texinfo \
             libx11-dev libxxf86vm-dev libxcursor-dev libxi-dev \
-            libxrandr-dev libxinerama-dev libxext-dev libegl-dev \
-            libwayland-dev wayland-protocols libxkbcommon-dev \
-            libdbus-1-dev linux-libc-dev libssl-dev libffi-dev \
+            libxrandr-dev libxinerama-dev libxext-dev libxt-dev libegl-dev \
+            libgles-dev libgbm-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev libpixman-1-dev \
+            libinput-dev libevdev-dev libdrm-dev libcairo2-dev \
+            libxcb-shm0-dev libx11-xcb-dev \
+            libdbus-1-dev libpipewire-0.3-dev libpulse-dev libasound2-dev \
+            linux-libc-dev libssl-dev libffi-dev \
             libreadline-dev libbz2-dev liblzma-dev zlib1g-dev \
             libsqlite3-dev
           git lfs install --skip-repo
@@ -69,7 +75,9 @@ jobs:
       - name: Cache native Blender ARM64 dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.buildbpy/lib
+          path: |
+            ~/.buildbpy/build_linux/deps_arm64
+            ~/.buildbpy/blender/lib/linux_arm64
           key: blender-${{ env.TAG }}-linux-arm64-deps-v1
 
       - name: Build and publish bpy
@@ -78,13 +86,13 @@ jobs:
         run: |
           python -m buildbpy.main \
             --tag "${TAG}" \
-            --install \
-            --publish
+            --install
 
       - name: Verify wheel architecture and import
         run: |
           python - <<'PY'
           from pathlib import Path
+          import os
           import platform
           import bpy
 
@@ -94,11 +102,77 @@ jobs:
           assert "cp313" in wheel.name, wheel.name
           assert "aarch64" in wheel.name, wheel.name
           assert platform.machine().lower() in {"aarch64", "arm64"}
-          assert bpy.app.version[:2] == (5, 2), bpy.app.version
+          expected_version = tuple(map(int, os.environ["TAG"].removeprefix("v").split(".")))
+          assert bpy.app.version == expected_version, (bpy.app.version, expected_version)
           print(f"wheel={wheel}")
           print(f"architecture={platform.machine()}")
           print(f"bpy_version={bpy.app.version_string}")
           PY
+
+      - name: Publish verified bpy wheel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release create "${TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${GITHUB_SHA}" \
+              --title "bpy-${TAG}" \
+              --notes "Blender Python Module for Blender ${TAG}"
+          fi
+          gh release upload "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            ~/.buildbpy/build_linux_bpy/bin/bpy-*.whl
+
+      - name: Package verified ARM64 dependency bundle
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          import subprocess
+
+          from buildbpy.arm64_deps import BundleSpec, create_bundle
+
+          root = Path.home() / ".buildbpy"
+          version = os.environ["TAG"].removeprefix("v")
+          commit = subprocess.check_output(
+              ["git", "-C", str(root / "blender"), "rev-parse", "HEAD"],
+              text=True,
+          ).strip()
+          artifacts = create_bundle(
+              root / "blender/lib/linux_arm64",
+              root / "deps-dist",
+              BundleSpec(version),
+              blender_commit=commit,
+              python_version=os.environ["PYTHON_VERSION"],
+          )
+          print(f"archive={artifacts.archive}")
+          print(f"manifest={artifacts.manifest}")
+          print(f"checksum={artifacts.checksum}")
+          PY
+
+      - name: Publish verified ARM64 dependency bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${TAG#v}"
+          RELEASE_TAG="deps-blender-${VERSION}-linux-arm64-v1"
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists and is immutable" >&2
+            exit 1
+          fi
+          gh release create "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "Blender ${VERSION} Linux ARM64 dependencies v1" \
+            --notes "Native Linux ARM64 dependency bundle validated by the bpy wheel build and import smoke test." \
+            --draft
+          gh release upload "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            ~/.buildbpy/deps-dist/*
+          gh release edit "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false
 
       - name: Upload ARM64 wheel artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_linux_arm64.yml
+++ b/.github/workflows/build_linux_arm64.yml
@@ -80,7 +80,7 @@ jobs:
             ~/.buildbpy/blender/lib/linux_arm64
           key: blender-${{ env.TAG }}-${{ env.PYTHON_VERSION }}-linux-arm64-deps-v1
 
-      - name: Build and publish bpy
+      - name: Build and install bpy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,39 @@ Unlike the official Blender bpy builds, this project's releases:
 - macOS (Intel and Apple Silicon)
 - Linux
 
+## Linux ARM64 dependency bundles
+
+Blender 5.2 does not publish the same precompiled dependency repository for
+Linux ARM64 that it publishes for Linux x86-64. On ARM64, `buildbpy` therefore:
+
+1. looks for a checksummed bundle in the `buildbpy` GitHub Releases;
+2. verifies its version/platform manifest and SHA-256 digest before extraction;
+3. falls back to a complete native `make deps` build when no bundle exists.
+
+Bundles use immutable release tags such as
+`deps-blender-5.2.0-linux-arm64-v1`; published assets are never clobbered in
+place. A successful ARM64 CI build packages and publishes the exact dependency
+tree only after the generated wheel installs and its exact requested Blender
+version passes `import bpy`.
+
+The bundle, manifest, and checksum are trusted through GitHub HTTPS and the
+repository's release-write access. SHA-256 detects corruption and mixed assets;
+it is not an independent publisher signature. Downloads use finite timeouts and
+atomic replacement, and unsafe archives or failed verification fall back to the
+native dependency build.
+
+For local/offline use, select an archive explicitly:
+
+```bash
+export BUILDBPY_ARM64_DEPS_ARCHIVE=/path/to/blender-5.2.0-linux-arm64-ubuntu24.04-gcc13-v1.tar.zst
+export BUILDBPY_ARM64_DEPS_MANIFEST="${BUILDBPY_ARM64_DEPS_ARCHIVE}.manifest.json"
+python -m buildbpy.main --tag v5.2.0 --install
+```
+
+Set `BUILDBPY_ARM64_DEPS_USE_RELEASE=0` to force native dependency compilation.
+For a private fork, set `BUILDBPY_DEPS_REPOSITORY=owner/repository` and provide
+`GITHUB_TOKEN` or `GH_TOKEN` with release-read access.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "python-dotenv",
     "bpystubgen",
     "click",
-    "aiohttp==3.8.6",
     "httpx==0.25.2",
     "PyGithub==2.1.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,5 @@ requests
 python-dotenv
 bpystubgen
 click
-aiohttp
-httpx
-PyGithub
-requests
-setuptools
-wheel
+httpx==0.25.2
+PyGithub==2.1.1

--- a/src/buildbpy/arm64_deps.py
+++ b/src/buildbpy/arm64_deps.py
@@ -233,30 +233,38 @@ def create_bundle(
 @contextmanager
 def _open_zstd_tar(archive: Path):
     stderr_file = tempfile.TemporaryFile()
-    process = subprocess.Popen(
-        ["zstd", "-dc", "--", str(archive)],
-        stdout=subprocess.PIPE,
-        stderr=stderr_file,
-    )
-    assert process.stdout is not None
     try:
-        with tarfile.open(fileobj=process.stdout, mode="r|") as tar:
-            yield tar
-    except BaseException:
-        process.kill()
-        process.wait()
-        raise
-    else:
-        process.stdout.close()
-        return_code = process.wait()
-        if return_code != 0:
-            stderr_file.seek(0)
-            stderr = stderr_file.read()
-            raise subprocess.CalledProcessError(
-                return_code, process.args, stderr=stderr
+        try:
+            process = subprocess.Popen(
+                ["zstd", "-dc", "--", str(archive)],
+                stdout=subprocess.PIPE,
+                stderr=stderr_file,
             )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "zstd executable is required to verify ARM64 dependency bundles"
+            ) from exc
+
+        assert process.stdout is not None
+        try:
+            with tarfile.open(fileobj=process.stdout, mode="r|") as tar:
+                yield tar
+        except BaseException:
+            process.kill()
+            process.wait()
+            raise
+        else:
+            process.stdout.close()
+            return_code = process.wait()
+            if return_code != 0:
+                stderr_file.seek(0)
+                stderr = stderr_file.read()
+                raise subprocess.CalledProcessError(
+                    return_code, process.args, stderr=stderr
+                )
+        finally:
+            process.stdout.close()
     finally:
-        process.stdout.close()
         stderr_file.close()
 
 

--- a/src/buildbpy/arm64_deps.py
+++ b/src/buildbpy/arm64_deps.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import subprocess
+import tarfile
+import tempfile
+from typing import Any
+
+import httpx
+
+
+RELEASE_TIMEOUT = httpx.Timeout(300.0, connect=30.0, write=30.0, pool=30.0)
+
+
+@dataclass(frozen=True)
+class BundleSpec:
+    blender_version: str
+    revision: int = 1
+    os_name: str = "ubuntu24.04"
+    compiler: str = "gcc13"
+    architecture: str = "arm64"
+
+    @property
+    def release_tag(self) -> str:
+        return (
+            f"deps-blender-{self.blender_version}-linux-"
+            f"{self.architecture}-v{self.revision}"
+        )
+
+    @property
+    def archive_name(self) -> str:
+        return (
+            f"blender-{self.blender_version}-linux-{self.architecture}-"
+            f"{self.os_name}-{self.compiler}-v{self.revision}.tar.zst"
+        )
+
+    @property
+    def manifest_name(self) -> str:
+        return f"{self.archive_name}.manifest.json"
+
+    @property
+    def checksum_name(self) -> str:
+        return f"{self.archive_name}.sha256"
+
+    def identity(self) -> dict[str, Any]:
+        return {
+            "blender_version": self.blender_version,
+            "bundle_revision": self.revision,
+            "os": self.os_name,
+            "compiler": self.compiler,
+            "architecture": self.architecture,
+        }
+
+
+@dataclass(frozen=True)
+class BundleArtifacts:
+    archive: Path
+    manifest: Path
+    checksum: Path
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def disable_arm64_osl_optix(osl_cmake: Path) -> bool:
+    """Prevent OSL's unsupported CUDA/OptiX bitcode build on Linux ARM64."""
+    original = "if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM))"
+    replacement = (
+        "if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM OR BLENDER_PLATFORM_ARM))"
+    )
+    text = osl_cmake.read_text()
+    if replacement in text:
+        return False
+    if original not in text:
+        raise ValueError(f"Unrecognized Blender OSL dependency configuration: {osl_cmake}")
+    osl_cmake.write_text(text.replace(original, replacement, 1))
+    return True
+
+
+def configure_arm64_wayland_lib64(wayland_cmake: Path) -> bool:
+    """Match Wayland's Meson install directory to Blender's harvest rules."""
+    text = wayland_cmake.read_text()
+    if "--libdir lib64" in text:
+        return False
+    prefix = "--prefix ${LIBDIR}/wayland\n"
+    if prefix not in text:
+        raise ValueError(
+            f"Unrecognized Blender Wayland dependency configuration: {wayland_cmake}"
+        )
+    prefix_start = text.rfind("\n", 0, text.index(prefix)) + 1
+    indentation = text[prefix_start : text.index(prefix)]
+    replacement = f"{prefix}{indentation}--libdir lib64\n"
+    wayland_cmake.write_text(text.replace(prefix, replacement, 1))
+    return True
+
+
+def download_release_bundle(
+    client: httpx.Client,
+    repository: str,
+    token: str,
+    spec: BundleSpec,
+    output_dir: Path,
+) -> BundleArtifacts | None:
+    api_headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        api_headers["Authorization"] = f"Bearer {token}"
+    response = client.get(
+        f"https://api.github.com/repos/{repository}/releases/tags/{spec.release_tag}",
+        headers=api_headers,
+        timeout=RELEASE_TIMEOUT,
+    )
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub release response must be a JSON object")
+    raw_assets = payload.get("assets")
+    if not isinstance(raw_assets, list):
+        raise ValueError("GitHub release response assets must be a list")
+    assets = {}
+    for asset in raw_assets:
+        if not isinstance(asset, dict):
+            raise ValueError("GitHub release asset must be a JSON object")
+        name = asset.get("name")
+        url = asset.get("url")
+        if not isinstance(name, str) or not isinstance(url, str):
+            raise ValueError("GitHub release asset name and URL must be strings")
+        assets[name] = url
+    required = [spec.archive_name, spec.manifest_name, spec.checksum_name]
+    if any(name not in assets for name in required):
+        return None
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    downloaded = []
+    asset_headers = {**api_headers, "Accept": "application/octet-stream"}
+    for name in required:
+        path = output_dir / name
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=output_dir,
+                prefix=f".{name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as file:
+                temporary_path = Path(file.name)
+                with client.stream(
+                    "GET",
+                    assets[name],
+                    headers=asset_headers,
+                    timeout=RELEASE_TIMEOUT,
+                ) as asset_response:
+                    asset_response.raise_for_status()
+                    for chunk in asset_response.iter_bytes():
+                        file.write(chunk)
+                file.flush()
+                os.fsync(file.fileno())
+            os.replace(temporary_path, path)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+        downloaded.append(path)
+    return BundleArtifacts(*downloaded)
+
+
+def create_bundle(
+    source: Path,
+    output_dir: Path,
+    spec: BundleSpec,
+    *,
+    blender_commit: str = "",
+    python_version: str = "",
+) -> BundleArtifacts:
+    source = source.resolve()
+    if not source.is_dir():
+        raise ValueError(f"Dependency source directory does not exist: {source}")
+    if source.name != "linux_arm64":
+        raise ValueError("Dependency source directory must be named linux_arm64")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive = output_dir / spec.archive_name
+    manifest_path = output_dir / spec.manifest_name
+    checksum_path = output_dir / spec.checksum_name
+
+    subprocess.run(
+        [
+            "tar",
+            "--zstd",
+            "--sort=name",
+            "--mtime=@0",
+            "--owner=0",
+            "--group=0",
+            "--numeric-owner",
+            "-cf",
+            str(archive),
+            "-C",
+            str(source.parent),
+            source.name,
+        ],
+        check=True,
+    )
+    archive_sha256 = sha256_file(archive)
+    manifest = {
+        **spec.identity(),
+        "release_tag": spec.release_tag,
+        "archive": spec.archive_name,
+        "archive_sha256": archive_sha256,
+        "blender_commit": blender_commit,
+        "python_version": python_version,
+        "builder_machine": platform.machine().lower(),
+        "format": 1,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    checksum_path.write_text(f"{archive_sha256}  {spec.archive_name}\n")
+    return BundleArtifacts(archive, manifest_path, checksum_path)
+
+
+@contextmanager
+def _open_zstd_tar(archive: Path):
+    stderr_file = tempfile.TemporaryFile()
+    process = subprocess.Popen(
+        ["zstd", "-dc", "--", str(archive)],
+        stdout=subprocess.PIPE,
+        stderr=stderr_file,
+    )
+    assert process.stdout is not None
+    try:
+        with tarfile.open(fileobj=process.stdout, mode="r|") as tar:
+            yield tar
+    except BaseException:
+        process.kill()
+        process.wait()
+        raise
+    else:
+        process.stdout.close()
+        return_code = process.wait()
+        if return_code != 0:
+            stderr_file.seek(0)
+            stderr = stderr_file.read()
+            raise subprocess.CalledProcessError(
+                return_code, process.args, stderr=stderr
+            )
+    finally:
+        process.stdout.close()
+        stderr_file.close()
+
+
+def _validate_archive_members(archive: Path, destination: Path) -> None:
+    with _open_zstd_tar(archive) as tar:
+        for info in tar:
+            member = PurePosixPath(info.name)
+            if member.is_absolute() or ".." in member.parts:
+                raise ValueError(f"Unsafe bundle member: {info.name}")
+            if not member.parts or member.parts[0] != "linux_arm64":
+                raise ValueError(
+                    f"Bundle member is outside linux_arm64: {info.name}"
+                )
+            if info.issym() or info.islnk():
+                link_name = PurePosixPath(info.linkname)
+                if link_name.is_absolute():
+                    raise ValueError(
+                        f"Unsafe bundle link: {info.name} -> {info.linkname}"
+                    )
+                target = member.parent / link_name if info.issym() else link_name
+                normalized_parts: list[str] = []
+                for part in target.parts:
+                    if part in {"", "."}:
+                        continue
+                    if part == "..":
+                        if not normalized_parts:
+                            raise ValueError(
+                                f"Unsafe bundle link: {info.name} -> {info.linkname}"
+                            )
+                        normalized_parts.pop()
+                    else:
+                        normalized_parts.append(part)
+                if not normalized_parts or normalized_parts[0] != "linux_arm64":
+                    raise ValueError(
+                        f"Unsafe bundle link: {info.name} -> {info.linkname}"
+                    )
+            try:
+                tarfile.data_filter(info, str(destination))
+            except tarfile.FilterError as exc:
+                raise ValueError(f"Unsafe bundle member: {info.name}: {exc}") from exc
+
+
+def verify_and_extract_bundle(
+    archive: Path,
+    manifest_path: Path,
+    checksum_path: Path,
+    destination: Path,
+    spec: BundleSpec,
+    *,
+    expected_blender_commit: str = "",
+    expected_python_series: str = "",
+) -> dict[str, Any]:
+    manifest = json.loads(manifest_path.read_text())
+    if not isinstance(manifest, dict):
+        raise ValueError("Dependency bundle manifest must be a JSON object")
+    expected_identity = spec.identity()
+    actual_identity = {key: manifest.get(key) for key in expected_identity}
+    if actual_identity != expected_identity:
+        raise ValueError(
+            f"Dependency bundle identity mismatch: {actual_identity} != {expected_identity}"
+        )
+    if manifest.get("archive") != archive.name:
+        raise ValueError("Dependency bundle archive name does not match manifest")
+    if manifest.get("release_tag") != spec.release_tag:
+        raise ValueError("Dependency bundle release tag does not match specification")
+    if manifest.get("format") != 1:
+        raise ValueError("Unsupported dependency bundle manifest format")
+    if expected_blender_commit and manifest.get("blender_commit") != expected_blender_commit:
+        raise ValueError("Dependency bundle Blender commit does not match checkout")
+    python_version = manifest.get("python_version")
+    if expected_python_series and (
+        not isinstance(python_version, str)
+        or not python_version.startswith(f"{expected_python_series}.")
+    ):
+        raise ValueError("Dependency bundle Python version is incompatible")
+    actual_sha256 = sha256_file(archive)
+    checksum_parts = checksum_path.read_text().split()
+    if (
+        len(checksum_parts) != 2
+        or checksum_parts[0] != actual_sha256
+        or checksum_parts[1] != archive.name
+    ):
+        raise ValueError("Dependency bundle checksum asset SHA-256 does not match archive")
+    if actual_sha256 != manifest.get("archive_sha256"):
+        raise ValueError("Dependency bundle SHA-256 does not match manifest")
+
+    _validate_archive_members(archive, destination)
+    destination.mkdir(parents=True, exist_ok=True)
+    with _open_zstd_tar(archive) as tar:
+        tar.extractall(destination, filter="data")
+    return manifest

--- a/src/buildbpy/arm64_deps.py
+++ b/src/buildbpy/arm64_deps.py
@@ -351,6 +351,12 @@ def verify_and_extract_bundle(
     if actual_sha256 != manifest.get("archive_sha256"):
         raise ValueError("Dependency bundle SHA-256 does not match manifest")
 
+    data_filter = getattr(tarfile, "data_filter", None)
+    if not callable(data_filter):
+        raise RuntimeError(
+            "Python tarfile extraction filters are required to install ARM64 "
+            "dependency bundles"
+        )
     _validate_archive_members(archive, destination)
     destination.mkdir(parents=True, exist_ok=True)
     with _open_zstd_tar(archive) as tar:

--- a/src/buildbpy/main.py
+++ b/src/buildbpy/main.py
@@ -861,6 +861,10 @@ class LinuxOSStrategy(OSStrategy):
         """
         logger.info(f"Running command: {command} in {cwd}")
 
+        if "update" in command:
+            self.run_update_command(command, cwd)
+            return
+
         # Use Popen to stream output in real-time
         process = subprocess.Popen(
             command,

--- a/src/buildbpy/main.py
+++ b/src/buildbpy/main.py
@@ -7,10 +7,19 @@ import dotenv
 import os
 import ssl
 import platform
+import sys
 import tarfile
 import zipfile
 import shutil
 from github import Github
+from .arm64_deps import (
+    BundleArtifacts,
+    BundleSpec,
+    configure_arm64_wayland_lib64,
+    disable_arm64_osl_optix,
+    download_release_bundle,
+    verify_and_extract_bundle,
+)
 from .utils import dmgextractor, make_utils
 from abc import ABC, abstractmethod
 import stat
@@ -301,6 +310,12 @@ class OSStrategy(ABC):
         # self.run_svn_checkout()
         self.run_command(f"{self.make_command} update", self.blender_repo_dir)
 
+    def get_bpy_build_command(self) -> str:
+        return f"{self.make_command} bpy"
+
+    def prepare_bpy_build(self) -> None:
+        pass
+
     def run_svn_checkout(self):
         print(f"Installing libraries to: {self.lib_dir}")
         subprocess.run(["svn", "checkout", self.lib_path], cwd=self.lib_dir)
@@ -323,7 +338,9 @@ class OSStrategy(ABC):
             cwd=cwd,
             shell=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            # Merge stderr into stdout so verbose native builds cannot fill an
+            # unread stderr pipe and deadlock while stdout is being streamed.
+            stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,  # Line buffered
             universal_newlines=True,
@@ -337,10 +354,8 @@ class OSStrategy(ABC):
             if output:
                 logger.info(output.strip())
 
-        # Get any remaining stderr
-        stderr = process.stderr.read()
-        if stderr:
-            logger.warning(stderr.strip())
+        # stderr is merged into stdout above to avoid pipe deadlocks.
+        stderr = ""
 
         # Check return code
         return_code = process.wait()
@@ -655,19 +670,127 @@ class LinuxOSStrategy(OSStrategy):
         self.build_wheel_dir = self.build_dir / "bin"
         self.make_command = "make"
 
+    def get_bpy_build_command(self) -> str:
+        if self.is_arm64:
+            return "CC=gcc-14 CXX=g++-14 make bpy"
+        return super().get_bpy_build_command()
+
+    def prepare_bpy_build(self) -> None:
+        if not self.is_arm64:
+            return
+        cache = self.build_dir / "CMakeCache.txt"
+        if cache.exists() and "gcc-14" not in cache.read_text(errors="replace"):
+            logger.info("Resetting bpy CMake cache to select GCC 14")
+            shutil.rmtree(self.build_dir)
+
+    def _install_arm64_bundle(
+        self, artifacts: BundleArtifacts, spec: BundleSpec
+    ) -> None:
+        extract_root = self.download_dir / "arm64-deps-extract"
+        if extract_root.exists():
+            shutil.rmtree(extract_root)
+        logger.info("Verifying Linux ARM64 dependency bundle %s", artifacts.archive)
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            extract_root,
+            spec,
+            expected_blender_commit=self.version_strategy.commit_hash,
+            expected_python_series=f"{sys.version_info.major}.{sys.version_info.minor}",
+        )
+        target = self.lib_dir / "linux_arm64"
+        if target.exists():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(extract_root / "linux_arm64"), str(target))
+        shutil.rmtree(extract_root)
+        logger.info("Installed verified Linux ARM64 dependency bundle")
+
     def setup_build_environment(self):
         """Override to use make_update.py instead of SVN for Linux"""
         if not self.lib_dir.exists():
             self.lib_dir.mkdir(parents=True, exist_ok=True)
         if self.is_arm64:
-            # Blender 5.2 has no lib/linux_arm64 precompiled dependency
-            # submodule. Update source/LFS without libraries, then build the
-            # complete dependency set natively before building bpy.
-            logger.info("Building Blender dependencies natively for Linux ARM64")
+            # Blender 5.2 has no upstream lib/linux_arm64 bundle. Prefer our
+            # verified release bundle, with a complete native build fallback.
             self.run_command(
                 "./build_files/utils/make_update.py --no-libraries",
                 self.blender_repo_dir,
             )
+            spec = BundleSpec(self.version_strategy.minor_version)
+            archive_value = os.environ.get("BUILDBPY_ARM64_DEPS_ARCHIVE")
+            if archive_value:
+                archive = Path(archive_value).expanduser().resolve()
+                manifest = Path(
+                    os.environ.get(
+                        "BUILDBPY_ARM64_DEPS_MANIFEST",
+                        f"{archive}.manifest.json",
+                    )
+                ).expanduser().resolve()
+                self._install_arm64_bundle(
+                    BundleArtifacts(archive, manifest, Path(f"{archive}.sha256")),
+                    spec,
+                )
+                return
+            if os.environ.get("BUILDBPY_ARM64_DEPS_USE_RELEASE", "1") != "0":
+                repository = os.environ.get(
+                    "BUILDBPY_DEPS_REPOSITORY",
+                    os.environ.get("GITHUB_REPOSITORY", "michaelgold/buildbpy"),
+                )
+                token = os.environ.get("GITHUB_TOKEN", os.environ.get("GH_TOKEN", ""))
+                try:
+                    with httpx.Client(timeout=None, follow_redirects=True) as client:
+                        artifacts = download_release_bundle(
+                            client,
+                            repository,
+                            token,
+                            spec,
+                            self.download_dir / "arm64-deps-release",
+                        )
+                    if artifacts is not None:
+                        self._install_arm64_bundle(artifacts, spec)
+                        return
+                    logger.info(
+                        "No complete ARM64 dependency release %s; building natively",
+                        spec.release_tag,
+                    )
+                except (
+                    httpx.HTTPError,
+                    OSError,
+                    ValueError,
+                    subprocess.CalledProcessError,
+                    tarfile.TarError,
+                ) as exc:
+                    logger.warning(
+                        "ARM64 dependency release is unavailable or invalid (%s); "
+                        "building natively",
+                        exc,
+                    )
+            osl_cmake = (
+                self.blender_repo_dir
+                / "build_files/build_environment/cmake/osl.cmake"
+            )
+            disable_arm64_osl_optix(osl_cmake)
+            osl_cache = (
+                self.root_dir
+                / "build_linux/deps_arm64/build/osl/src/external_osl-build/CMakeCache.txt"
+            )
+            if osl_cache.exists() and "OSL_USE_OPTIX:BOOL=ON" in osl_cache.read_text(
+                errors="replace"
+            ):
+                logger.info("Resetting OSL build configured with unsupported ARM64 OptiX")
+                shutil.rmtree(self.root_dir / "build_linux/deps_arm64/build/osl")
+            wayland_cmake = (
+                self.blender_repo_dir
+                / "build_files/build_environment/cmake/wayland.cmake"
+            )
+            if configure_arm64_wayland_lib64(wayland_cmake):
+                wayland_build = self.root_dir / "build_linux/deps_arm64/build/wayland"
+                harvested_wayland_lib64 = self.lib_dir / "linux_arm64/wayland/lib64"
+                if wayland_build.exists() and not harvested_wayland_lib64.exists():
+                    logger.info("Resetting Wayland build to install libraries under lib64")
+                    shutil.rmtree(wayland_build)
             self.run_command(f"{self.make_command} deps", self.blender_repo_dir)
             return
         logger.info(f"Installing libraries using make_update.py in {self.lib_dir}")
@@ -744,7 +867,9 @@ class LinuxOSStrategy(OSStrategy):
             cwd=cwd,
             shell=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            # Merge stderr into stdout so verbose native builds cannot fill an
+            # unread stderr pipe and deadlock while stdout is being streamed.
+            stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,  # Line buffered
             universal_newlines=True,
@@ -758,10 +883,8 @@ class LinuxOSStrategy(OSStrategy):
             if output:
                 logger.info(output.strip())
 
-        # Get any remaining stderr
-        stderr = process.stderr.read()
-        if stderr:
-            logger.warning(stderr.strip())
+        # stderr is merged into stdout above to avoid pipe deadlocks.
+        stderr = ""
 
         # Check return code
         return_code = process.wait()
@@ -1070,14 +1193,23 @@ class BlenderBuilder:
 
         make_script = self.blender_repo_dir / "build_files/utils/make_bpy_wheel.py"
         print(f"Running python {make_script} {bin_path}")
-        subprocess.run(["python", make_script, bin_path])
+        subprocess.run([sys.executable, make_script, bin_path], check=True)
 
         if install:
             wheel_file = next(bin_path.glob("*.whl"), None)
             if wheel_file:
                 print("Installing the wheel")
                 subprocess.run(
-                    ["pip", "install", "--force-reinstall", "--no-deps", wheel_file]
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--force-reinstall",
+                        "--no-deps",
+                        wheel_file,
+                    ],
+                    check=True,
                 )
 
         if publish:
@@ -1125,6 +1257,13 @@ class BlenderBuilder:
             logger.info(f"Checking out daily version {daily_version}")
             self.checkout_strategy.checkout()
 
+        commit_hash = subprocess.check_output(
+            ["git", "-C", str(blender_repo_dir), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+        if not commit_hash:
+            raise RuntimeError("Unable to resolve checked-out Blender commit")
+
         # Get Blender version and setup build
         logger.info("Setting version from checkout strategy")
         self.checkout_strategy.set_version(commit_hash, tag)
@@ -1159,7 +1298,6 @@ class BlenderBuilder:
             logger.info(f"Clearing lib directory {self.lib_dir}")
             shutil.rmtree(self.lib_dir)
 
-        make_command = self.os_strategy.make_command
         logger.info("Calling setup_build_environment")
         self.os_strategy.setup_build_environment()
 
@@ -1170,8 +1308,10 @@ class BlenderBuilder:
         self.os_strategy.set_cmake_directives()
         os.chdir(blender_repo_dir)
 
-        logger.info(f"Running make command: {make_command} bpy")
-        self.os_strategy.run_command(f"{make_command} bpy", blender_repo_dir)
+        self.os_strategy.prepare_bpy_build()
+        bpy_build_command = self.os_strategy.get_bpy_build_command()
+        logger.info(f"Running make command: {bpy_build_command}")
+        self.os_strategy.run_command(bpy_build_command, blender_repo_dir)
 
         # Build and install or publish the wheel
         wheel_path = self.os_strategy.build_wheel_dir

--- a/src/buildbpy/main.py
+++ b/src/buildbpy/main.py
@@ -277,7 +277,7 @@ class OSStrategy(ABC):
     ):
         self.blender_repo_dir = blender_repo_dir
         self.build_dir: Path = None
-        self.lib_path: Path = None
+        self.lib_path: str = ""
         self.root_dir = root_dir
         self.bin_dir = self.root_dir / "blender-bin"
         self.download_dir = self.root_dir / "downloads"
@@ -408,7 +408,7 @@ class OSStrategy(ABC):
         pass
 
     @abstractmethod
-    def get_arch(self):
+    def get_arch(self) -> str:
         pass
 
     @abstractmethod
@@ -643,8 +643,14 @@ class LinuxOSStrategy(OSStrategy):
         blender_repo_dir: Path,
         http_client: httpx.Client,
     ):
+        machine = platform.machine().lower()
+        self.is_arm64 = machine in {"aarch64", "arm64"}
         super().__init__(version_strategy, root_dir, blender_repo_dir, http_client)
-        self.lib_path = f"{self.version_strategy.get_svn_root()}linux_x86_64_glibc_228"
+        self.lib_path = (
+            f"{self.version_strategy.get_svn_root()}linux_arm64"
+            if self.is_arm64
+            else f"{self.version_strategy.get_svn_root()}linux_x86_64_glibc_228"
+        )
         self.build_dir = self.root_dir / "build_linux_bpy"
         self.build_wheel_dir = self.build_dir / "bin"
         self.make_command = "make"
@@ -653,6 +659,17 @@ class LinuxOSStrategy(OSStrategy):
         """Override to use make_update.py instead of SVN for Linux"""
         if not self.lib_dir.exists():
             self.lib_dir.mkdir(parents=True, exist_ok=True)
+        if self.is_arm64:
+            # Blender 5.2 has no lib/linux_arm64 precompiled dependency
+            # submodule. Update source/LFS without libraries, then build the
+            # complete dependency set natively before building bpy.
+            logger.info("Building Blender dependencies natively for Linux ARM64")
+            self.run_command(
+                "./build_files/utils/make_update.py --no-libraries",
+                self.blender_repo_dir,
+            )
+            self.run_command(f"{self.make_command} deps", self.blender_repo_dir)
+            return
         logger.info(f"Installing libraries using make_update.py in {self.lib_dir}")
         self.run_command(
             f"./build_files/utils/make_update.py --use-linux-libraries",
@@ -684,8 +701,9 @@ class LinuxOSStrategy(OSStrategy):
         return system_type
 
     def get_arch(self):
-        arch = "x64" if self.version_strategy.release_cycle == "release" else "x86_64"
-        return arch
+        if self.is_arm64:
+            return "arm64"
+        return "x64" if self.version_strategy.release_cycle == "release" else "x86_64"
 
     def get_file_ext(self):
         return "tar.xz"
@@ -970,6 +988,15 @@ class BlenderBuilder:
         Returns:
             None
         """
+        if (
+            self.os_type == "Linux"
+            and platform.machine().lower() in {"aarch64", "arm64"}
+        ):
+            # Blender does not publish a Linux ARM64 application archive.
+            # Stub generation is not required to build or package bpy.
+            logger.info("Skipping pre-build stubs: no official Linux ARM64 Blender binary")
+            return
+
         downloaded_file = self.os_strategy.download_file()
         self.os_strategy.extract(downloaded_file)
         blender_binary = self.os_strategy.get_blender_binary()

--- a/src/buildbpy/main.py
+++ b/src/buildbpy/main.py
@@ -758,6 +758,7 @@ class LinuxOSStrategy(OSStrategy):
                 except (
                     httpx.HTTPError,
                     OSError,
+                    RuntimeError,
                     ValueError,
                     subprocess.CalledProcessError,
                     tarfile.TarError,

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 
 from buildbpy.arm64_deps import (
+    BundleArtifacts,
     BundleSpec,
     _open_zstd_tar,
     configure_arm64_wayland_lib64,
@@ -514,9 +515,58 @@ def test_linux_arm64_falls_back_when_release_bundle_is_invalid(
     ]
 
 
+def test_linux_arm64_falls_back_when_bundle_decoder_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    blender_repo = tmp_path / "blender"
+    cmake_dir = blender_repo / "build_files/build_environment/cmake"
+    cmake_dir.mkdir(parents=True)
+    (cmake_dir / "osl.cmake").write_text(
+        "if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM))\nendif()\n"
+    )
+    (cmake_dir / "wayland.cmake").write_text(
+        "${MESON} setup\n  --prefix ${LIBDIR}/wayland\n  ${MESON_BUILD_TYPE}\n"
+    )
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    commands = []
+    artifact = tmp_path / "placeholder"
+    artifacts = BundleArtifacts(artifact, artifact, artifact)
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_ARCHIVE", raising=False)
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_USE_RELEASE", raising=False)
+    monkeypatch.setattr(strategy, "run_command", lambda command, cwd: commands.append(command))
+    monkeypatch.setattr(
+        "buildbpy.main.download_release_bundle", lambda *args, **kwargs: artifacts
+    )
+    monkeypatch.setattr(
+        strategy,
+        "_install_arm64_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("missing zstd")),
+    )
+
+    strategy.setup_build_environment()
+
+    assert commands == [
+        "./build_files/utils/make_update.py --no-libraries",
+        "make deps",
+    ]
+
+
 def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
     workflow = Path(".github/workflows/build_linux_arm64.yml").read_text()
 
+    assert "TAG: ${{ inputs.tag || github.event.inputs.tag }}" in workflow
+    assert (
+        "PYTHON_VERSION: ${{ inputs.python_version || github.event.inputs.python_version }}"
+        in workflow
+    )
+    assert (
+        'expected_abi = "cp" + "".join(os.environ["PYTHON_VERSION"].split(".")[:2])'
+        in workflow
+    )
+    assert 'assert f"-{expected_abi}-{expected_abi}-" in wheel.name' in workflow
+    assert 'assert "cp313" in wheel.name' not in workflow
     assert (
         'expected_version = tuple(map(int, os.environ["TAG"].removeprefix("v").split(".")))'
         in workflow

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -483,6 +483,18 @@ def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
     assert "already exists and is immutable" not in workflow
 
 
+def test_build_all_includes_linux_arm64_in_aggregate_success_barrier():
+    workflow = Path(".github/workflows/build_all.yml").read_text()
+
+    assert "build-for-linux-arm64:" in workflow
+    assert "uses: ./.github/workflows/build_linux_arm64.yml" in workflow
+    assert "tag: ${{ needs.check-version.outputs.tag_input }}" in workflow
+    assert "python_version: ${{ needs.check-version.outputs.python_version }}" in workflow
+    update_section = workflow.split("  update-versions:", 1)[1]
+    update_needs = update_section.split("\n    if:", 1)[0]
+    assert "build-for-linux-arm64" in update_needs
+
+
 def test_download_release_bundle_rejects_non_object_api_payload(tmp_path: Path):
     spec = BundleSpec(blender_version="5.2.0", revision=1)
 

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -37,7 +37,8 @@ def _arm64_bundle_tools_available() -> bool:
     )
 
 
-pytestmark = pytest.mark.skipif(
+REPO_ROOT = Path(__file__).resolve().parents[1]
+requires_bundle_tools = pytest.mark.skipif(
     not _arm64_bundle_tools_available(),
     reason="Linux ARM64 bundle tests require GNU tar with zstd support and zstd",
 )
@@ -114,6 +115,7 @@ def test_arm64_wayland_patch_uses_harvested_lib64_directory(tmp_path: Path):
     assert configure_arm64_wayland_lib64(wayland_cmake) is False
 
 
+@requires_bundle_tools
 def test_bundle_round_trip_verifies_and_extracts(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     (source / "lib").mkdir(parents=True)
@@ -143,6 +145,27 @@ def test_bundle_round_trip_verifies_and_extracts(tmp_path: Path):
     assert artifacts.checksum.read_text().split()[1] == spec.archive_name
 
 
+@requires_bundle_tools
+def test_bundle_requires_hardened_tarfile_extraction_api(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    monkeypatch.setattr(tarfile, "data_filter", None)
+
+    with pytest.raises(RuntimeError, match="tarfile extraction filters"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            spec,
+        )
+
+
+@requires_bundle_tools
 def test_bundle_rejects_modified_archive(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -161,6 +184,7 @@ def test_bundle_rejects_modified_archive(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_bundle_rejects_modified_checksum_asset(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -179,6 +203,7 @@ def test_bundle_rejects_modified_checksum_asset(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_bundle_rejects_manifest_for_another_version(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -196,6 +221,7 @@ def test_bundle_rejects_manifest_for_another_version(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_bundle_rejects_symlink_target_outside_prefix(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -230,6 +256,7 @@ def test_bundle_rejects_symlink_target_outside_prefix(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_linux_arm64_uses_verified_local_bundle_instead_of_make_deps(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -438,6 +465,7 @@ def test_interrupted_release_download_preserves_existing_asset(tmp_path: Path):
     assert list(tmp_path.glob("*.tmp")) == []
 
 
+@requires_bundle_tools
 def test_linux_arm64_uses_github_release_bundle_by_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -478,6 +506,7 @@ def test_linux_arm64_uses_github_release_bundle_by_default(
     assert (blender_repo / "lib/linux_arm64/lib/libexample.a").read_bytes() == b"release"
 
 
+@requires_bundle_tools
 def test_linux_arm64_falls_back_when_release_bundle_is_invalid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -554,7 +583,7 @@ def test_linux_arm64_falls_back_when_bundle_decoder_is_unavailable(
 
 
 def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
-    workflow = Path(".github/workflows/build_linux_arm64.yml").read_text()
+    workflow = (REPO_ROOT / ".github/workflows/build_linux_arm64.yml").read_text()
 
     assert "TAG: ${{ inputs.tag || github.event.inputs.tag }}" in workflow
     assert (
@@ -582,10 +611,11 @@ def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
     assert "id: deps_release" in workflow
     assert workflow.count("steps.deps_release.outputs.exists != 'true'") == 2
     assert "already exists and is immutable" not in workflow
+    assert "key: blender-${{ env.TAG }}-${{ env.PYTHON_VERSION }}-linux-arm64-deps-v1" in workflow
 
 
 def test_build_all_includes_linux_arm64_in_aggregate_success_barrier():
-    workflow = Path(".github/workflows/build_all.yml").read_text()
+    workflow = (REPO_ROOT / ".github/workflows/build_all.yml").read_text()
 
     assert "build-for-linux-arm64:" in workflow
     assert "uses: ./.github/workflows/build_linux_arm64.yml" in workflow
@@ -598,6 +628,12 @@ def test_build_all_includes_linux_arm64_in_aggregate_success_barrier():
     assert 'git config user.name "github-actions[bot]"' in workflow
     assert "git add -- workspace/version_info.json" in workflow
     assert 'git push origin "HEAD:${GITHUB_REF_NAME}"' in workflow
+
+
+def test_requirements_match_removed_aiohttp_dependency():
+    requirements = (REPO_ROOT / "requirements.txt").read_text().splitlines()
+
+    assert "aiohttp" not in requirements
 
 
 def test_download_release_bundle_rejects_non_object_api_payload(tmp_path: Path):
@@ -613,6 +649,7 @@ def test_download_release_bundle_rejects_non_object_api_payload(tmp_path: Path):
             )
 
 
+@requires_bundle_tools
 def test_bundle_rejects_link_outside_linux_arm64_subtree(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -646,6 +683,7 @@ def test_bundle_rejects_link_outside_linux_arm64_subtree(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_bundle_rejects_non_object_manifest(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -663,6 +701,7 @@ def test_bundle_rejects_non_object_manifest(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_bundle_validates_manifest_provenance(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()
@@ -702,6 +741,7 @@ def test_bundle_validates_manifest_provenance(tmp_path: Path):
         )
 
 
+@requires_bundle_tools
 def test_zstd_decoder_large_stderr_does_not_deadlock(tmp_path: Path):
     source = tmp_path / "linux_arm64"
     source.mkdir()

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -1,0 +1,659 @@
+from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from unittest.mock import patch
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from buildbpy.arm64_deps import (
+    BundleSpec,
+    configure_arm64_wayland_lib64,
+    create_bundle,
+    disable_arm64_osl_optix,
+    download_release_bundle,
+    sha256_file,
+    verify_and_extract_bundle,
+)
+from buildbpy.main import BlenderBuilder, LinuxOSStrategy, ReleaseVersionCycleStrategy
+
+
+def test_bundle_spec_has_stable_release_names():
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+
+    assert spec.release_tag == "deps-blender-5.2.0-linux-arm64-v1"
+    assert spec.archive_name == "blender-5.2.0-linux-arm64-ubuntu24.04-gcc13-v1.tar.zst"
+    assert spec.manifest_name == f"{spec.archive_name}.manifest.json"
+    assert spec.checksum_name == f"{spec.archive_name}.sha256"
+
+
+def test_arm64_osl_patch_disables_cuda_optix_only_on_arm(tmp_path: Path):
+    osl_cmake = tmp_path / "osl.cmake"
+    osl_cmake.write_text(
+        "if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM))\n"
+        "  list(APPEND OSL_EXTRA_ARGS -DOSL_USE_OPTIX=ON)\n"
+        "endif()\n"
+    )
+
+    changed = disable_arm64_osl_optix(osl_cmake)
+
+    assert changed is True
+    assert "BLENDER_PLATFORM_ARM" in osl_cmake.read_text()
+    assert disable_arm64_osl_optix(osl_cmake) is False
+
+
+def test_arm64_wayland_patch_uses_harvested_lib64_directory(tmp_path: Path):
+    wayland_cmake = tmp_path / "wayland.cmake"
+    wayland_cmake.write_text(
+        "${MESON} setup\n"
+        "  --prefix ${LIBDIR}/wayland\n"
+        "  ${MESON_BUILD_TYPE}\n"
+    )
+
+    changed = configure_arm64_wayland_lib64(wayland_cmake)
+
+    assert changed is True
+    assert "--libdir lib64" in wayland_cmake.read_text()
+    assert configure_arm64_wayland_lib64(wayland_cmake) is False
+
+
+def test_bundle_round_trip_verifies_and_extracts(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    (source / "lib").mkdir(parents=True)
+    (source / "lib" / "libexample.a").write_bytes(b"arm64-library")
+    output = tmp_path / "dist"
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+
+    artifacts = create_bundle(
+        source,
+        output,
+        spec,
+        blender_commit="abc123",
+        python_version="3.13.12",
+    )
+    destination = tmp_path / "installed"
+    manifest = verify_and_extract_bundle(
+        artifacts.archive,
+        artifacts.manifest,
+        artifacts.checksum,
+        destination,
+        spec,
+    )
+
+    assert (destination / "linux_arm64/lib/libexample.a").read_bytes() == b"arm64-library"
+    assert manifest["blender_commit"] == "abc123"
+    assert manifest["python_version"] == "3.13.12"
+    assert artifacts.checksum.read_text().split()[1] == spec.archive_name
+
+
+def test_bundle_rejects_modified_archive(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    (source / "value").write_text("original")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    artifacts.archive.write_bytes(artifacts.archive.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            spec,
+        )
+
+
+def test_bundle_rejects_modified_checksum_asset(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    (source / "value").write_text("original")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    artifacts.checksum.write_text(f"{'0' * 64}  {spec.archive_name}\n")
+
+    with pytest.raises(ValueError, match="checksum asset"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            spec,
+        )
+
+
+def test_bundle_rejects_manifest_for_another_version(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    (source / "value").write_text("original")
+    source_spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", source_spec)
+
+    with pytest.raises(ValueError, match="bundle identity"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            BundleSpec(blender_version="5.3.0", revision=1),
+        )
+
+
+def test_bundle_rejects_symlink_target_outside_prefix(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    (source / "value").write_text("original")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    raw_tar = tmp_path / "malicious.tar"
+    with tarfile.open(raw_tar, "w") as archive:
+        root = tarfile.TarInfo("linux_arm64")
+        root.type = tarfile.DIRTYPE
+        archive.addfile(root)
+        link = tarfile.TarInfo("linux_arm64/outside")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside"
+        archive.addfile(link)
+    subprocess.run(
+        ["zstd", "-f", str(raw_tar), "-o", str(artifacts.archive)], check=True
+    )
+    digest = sha256_file(artifacts.archive)
+    manifest = json.loads(artifacts.manifest.read_text())
+    manifest["archive_sha256"] = digest
+    artifacts.manifest.write_text(json.dumps(manifest))
+    artifacts.checksum.write_text(f"{digest}  {spec.archive_name}\n")
+
+    with pytest.raises(ValueError, match="Unsafe bundle (member|link)"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            spec,
+        )
+
+
+def test_linux_arm64_uses_verified_local_bundle_instead_of_make_deps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source" / "linux_arm64"
+    (source / "lib").mkdir(parents=True)
+    (source / "lib" / "libexample.a").write_bytes(b"compiled")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(
+        source,
+        tmp_path / "dist",
+        spec,
+        blender_commit="abc123",
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}.0",
+    )
+    blender_repo = tmp_path / "blender"
+    blender_repo.mkdir()
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    commands = []
+    monkeypatch.setenv("BUILDBPY_ARM64_DEPS_ARCHIVE", str(artifacts.archive))
+    monkeypatch.setenv("BUILDBPY_ARM64_DEPS_MANIFEST", str(artifacts.manifest))
+    monkeypatch.setattr(strategy, "run_command", lambda command, cwd: commands.append(command))
+
+    strategy.setup_build_environment()
+
+    assert commands == ["./build_files/utils/make_update.py --no-libraries"]
+    assert (blender_repo / "lib/linux_arm64/lib/libexample.a").read_bytes() == b"compiled"
+
+
+def test_linux_arm64_builds_bpy_with_gcc14(tmp_path: Path):
+    blender_repo = tmp_path / "blender"
+    blender_repo.mkdir()
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    stale_cache = strategy.build_dir / "CMakeCache.txt"
+    stale_cache.parent.mkdir(parents=True)
+    stale_cache.write_text(
+        "CMAKE_C_COMPILER:FILEPATH=/usr/bin/cc\n"
+        "CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/c++\n"
+    )
+
+    strategy.prepare_bpy_build()
+
+    assert strategy.get_bpy_build_command() == "CC=gcc-14 CXX=g++-14 make bpy"
+    assert not strategy.build_dir.exists()
+
+
+def test_linux_arm64_falls_back_to_native_dependencies_without_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    blender_repo = tmp_path / "blender"
+    blender_repo.mkdir()
+    osl_cmake = blender_repo / "build_files/build_environment/cmake/osl.cmake"
+    osl_cmake.parent.mkdir(parents=True)
+    osl_cmake.write_text("if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM))\nendif()\n")
+    wayland_cmake = osl_cmake.with_name("wayland.cmake")
+    wayland_cmake.write_text(
+        "${MESON} setup\n"
+        "  --prefix ${LIBDIR}/wayland\n"
+        "  ${MESON_BUILD_TYPE}\n"
+    )
+    stale_wayland_build = tmp_path / "build_linux/deps_arm64/build/wayland"
+    stale_wayland_build.mkdir(parents=True)
+    (stale_wayland_build / "configured-with-lib").write_text("stale")
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    commands = []
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_ARCHIVE", raising=False)
+    monkeypatch.setenv("BUILDBPY_ARM64_DEPS_USE_RELEASE", "0")
+    monkeypatch.setattr(strategy, "run_command", lambda command, cwd: commands.append(command))
+
+    strategy.setup_build_environment()
+
+    assert commands == [
+        "./build_files/utils/make_update.py --no-libraries",
+        "make deps",
+    ]
+    assert "--libdir lib64" in wayland_cmake.read_text()
+    assert not stale_wayland_build.exists()
+
+
+def test_linux_arm64_keeps_wayland_cache_after_lib64_was_harvested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    blender_repo = tmp_path / "blender"
+    cmake_dir = blender_repo / "build_files/build_environment/cmake"
+    cmake_dir.mkdir(parents=True)
+    (cmake_dir / "osl.cmake").write_text(
+        "if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM))\nendif()\n"
+    )
+    (cmake_dir / "wayland.cmake").write_text(
+        "  --prefix ${LIBDIR}/wayland\n  ${MESON_BUILD_TYPE}\n"
+    )
+    wayland_build = tmp_path / "build_linux/deps_arm64/build/wayland"
+    wayland_build.mkdir(parents=True)
+    harvested_lib64 = blender_repo / "lib/linux_arm64/wayland/lib64"
+    harvested_lib64.mkdir(parents=True)
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    monkeypatch.setenv("BUILDBPY_ARM64_DEPS_USE_RELEASE", "0")
+    monkeypatch.setattr(strategy, "run_command", lambda command, cwd: None)
+
+    strategy.setup_build_environment()
+
+    assert wayland_build.exists()
+
+
+def test_wheel_build_and_install_use_running_python_and_check_failures(tmp_path: Path):
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    builder = type("Builder", (), {"blender_repo_dir": tmp_path / "blender"})()
+
+    def create_wheel(*args, **kwargs):
+        if not list(bin_path.glob("*.whl")):
+            (bin_path / "bpy-5.2.0-cp313-cp313-manylinux_2_39_aarch64.whl").touch()
+
+    with patch("buildbpy.main.subprocess.run", side_effect=create_wheel) as run:
+        BlenderBuilder.build_and_manage_wheel(
+            builder, bin_path, True, False, "", "v5.2.0"
+        )
+
+    assert run.call_args_list[0].args[0][0] == sys.executable
+    assert run.call_args_list[0].kwargs["check"] is True
+    assert run.call_args_list[1].args[0][:3] == [sys.executable, "-m", "pip"]
+    assert run.call_args_list[1].kwargs["check"] is True
+
+
+def test_download_release_bundle_streams_named_assets(tmp_path: Path):
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    payloads = {
+        spec.archive_name: b"archive-bytes",
+        spec.manifest_name: b'{"archive": "test"}',
+        spec.checksum_name: b"checksum  archive\n",
+    }
+
+    request_timeouts = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_timeouts.append(request.extensions["timeout"])
+        if request.url.path.endswith(f"/releases/tags/{spec.release_tag}"):
+            assets = [
+                {
+                    "name": name,
+                    "url": f"https://api.github.test/assets/{index}",
+                }
+                for index, name in enumerate(payloads)
+            ]
+            return httpx.Response(200, json={"assets": assets})
+        index = int(request.url.path.rsplit("/", 1)[1])
+        return httpx.Response(200, content=list(payloads.values())[index])
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        artifacts = download_release_bundle(
+            client,
+            "michaelgold/buildbpy",
+            "token",
+            spec,
+            tmp_path,
+        )
+
+    assert artifacts is not None
+    assert artifacts.archive.read_bytes() == payloads[spec.archive_name]
+    assert artifacts.manifest.read_bytes() == payloads[spec.manifest_name]
+    assert artifacts.checksum.read_bytes() == payloads[spec.checksum_name]
+    assert all(
+        all(value is not None for value in timeout.values())
+        for timeout in request_timeouts
+    )
+
+
+def test_interrupted_release_download_preserves_existing_asset(tmp_path: Path):
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    existing = tmp_path / spec.archive_name
+    existing.write_bytes(b"previous-valid-archive")
+
+    class BrokenStream(httpx.SyncByteStream):
+        def __iter__(self):
+            yield b"partial"
+            raise httpx.ReadError("interrupted")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith(f"/releases/tags/{spec.release_tag}"):
+            return httpx.Response(
+                200,
+                json={
+                    "assets": [
+                        {"name": spec.archive_name, "url": "https://api.github.test/a"},
+                        {"name": spec.manifest_name, "url": "https://api.github.test/m"},
+                        {"name": spec.checksum_name, "url": "https://api.github.test/s"},
+                    ]
+                },
+            )
+        return httpx.Response(200, stream=BrokenStream())
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.ReadError, match="interrupted"):
+            download_release_bundle(
+                client, "michaelgold/buildbpy", "token", spec, tmp_path
+            )
+
+    assert existing.read_bytes() == b"previous-valid-archive"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_linux_arm64_uses_github_release_bundle_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source" / "linux_arm64"
+    (source / "lib").mkdir(parents=True)
+    (source / "lib" / "libexample.a").write_bytes(b"release")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(
+        source,
+        tmp_path / "release",
+        spec,
+        blender_commit="abc123",
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}.0",
+    )
+    blender_repo = tmp_path / "blender"
+    blender_repo.mkdir()
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    commands = []
+    calls = []
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_ARCHIVE", raising=False)
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_USE_RELEASE", raising=False)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "michaelgold/buildbpy")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(strategy, "run_command", lambda command, cwd: commands.append(command))
+
+    def fake_download(client, repository, token, bundle_spec, output_dir):
+        calls.append((repository, token, bundle_spec, output_dir))
+        return artifacts
+
+    monkeypatch.setattr("buildbpy.main.download_release_bundle", fake_download)
+
+    strategy.setup_build_environment()
+
+    assert commands == ["./build_files/utils/make_update.py --no-libraries"]
+    assert calls[0][0:2] == ("michaelgold/buildbpy", "token")
+    assert (blender_repo / "lib/linux_arm64/lib/libexample.a").read_bytes() == b"release"
+
+
+def test_linux_arm64_falls_back_when_release_bundle_is_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source" / "linux_arm64"
+    source.mkdir(parents=True)
+    (source / "value").write_text("release")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "release", spec)
+    artifacts.checksum.write_text(f"{'0' * 64}  {spec.archive_name}\n")
+    blender_repo = tmp_path / "blender"
+    cmake_dir = blender_repo / "build_files/build_environment/cmake"
+    cmake_dir.mkdir(parents=True)
+    (cmake_dir / "osl.cmake").write_text(
+        "if(NOT (APPLE OR BLENDER_PLATFORM_WINDOWS_ARM))\nendif()\n"
+    )
+    (cmake_dir / "wayland.cmake").write_text(
+        "${MESON} setup\n  --prefix ${LIBDIR}/wayland\n  ${MESON_BUILD_TYPE}\n"
+    )
+    version = ReleaseVersionCycleStrategy("5.2", "5.2.0", "release", "abc123")
+    with patch("platform.machine", return_value="aarch64"):
+        strategy = LinuxOSStrategy(version, tmp_path, blender_repo, httpx.Client())
+    commands = []
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_ARCHIVE", raising=False)
+    monkeypatch.delenv("BUILDBPY_ARM64_DEPS_USE_RELEASE", raising=False)
+    monkeypatch.setattr(strategy, "run_command", lambda command, cwd: commands.append(command))
+    monkeypatch.setattr(
+        "buildbpy.main.download_release_bundle", lambda *args, **kwargs: artifacts
+    )
+
+    strategy.setup_build_environment()
+
+    assert commands == [
+        "./build_files/utils/make_update.py --no-libraries",
+        "make deps",
+    ]
+
+
+def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
+    workflow = Path(".github/workflows/build_linux_arm64.yml").read_text()
+
+    assert (
+        'expected_version = tuple(map(int, os.environ["TAG"].removeprefix("v").split(".")))'
+        in workflow
+    )
+    assert "assert bpy.app.version == expected_version" in workflow
+    assert "gh release create" in workflow and "--draft" in workflow
+    assert "gh release edit" in workflow and "--draft=false" in workflow
+    assert "--clobber" not in workflow
+    verify_offset = workflow.index("- name: Verify wheel architecture and import")
+    assert "--publish" not in workflow[:verify_offset]
+    assert workflow.index("- name: Publish verified bpy wheel") > verify_offset
+
+
+def test_download_release_bundle_rejects_non_object_api_payload(tmp_path: Path):
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ValueError, match="release response must be a JSON object"):
+            download_release_bundle(
+                client, "michaelgold/buildbpy", "token", spec, tmp_path
+            )
+
+
+def test_bundle_rejects_link_outside_linux_arm64_subtree(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    raw_tar = tmp_path / "malicious.tar"
+    with tarfile.open(raw_tar, "w") as archive:
+        root = tarfile.TarInfo("linux_arm64")
+        root.type = tarfile.DIRTYPE
+        archive.addfile(root)
+        link = tarfile.TarInfo("linux_arm64/escape")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../sibling"
+        archive.addfile(link)
+    subprocess.run(
+        ["zstd", "-f", str(raw_tar), "-o", str(artifacts.archive)], check=True
+    )
+    digest = sha256_file(artifacts.archive)
+    manifest = json.loads(artifacts.manifest.read_text())
+    manifest["archive_sha256"] = digest
+    artifacts.manifest.write_text(json.dumps(manifest))
+    artifacts.checksum.write_text(f"{digest}  {spec.archive_name}\n")
+
+    with pytest.raises(ValueError, match="Unsafe bundle link"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            spec,
+        )
+
+
+def test_bundle_rejects_non_object_manifest(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    artifacts.manifest.write_text("[]")
+
+    with pytest.raises(ValueError, match="manifest must be a JSON object"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "installed",
+            spec,
+        )
+
+
+def test_bundle_validates_manifest_provenance(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(
+        source,
+        tmp_path / "dist",
+        spec,
+        blender_commit="expected-commit",
+        python_version="3.13.12",
+    )
+
+    manifest = verify_and_extract_bundle(
+        artifacts.archive,
+        artifacts.manifest,
+        artifacts.checksum,
+        tmp_path / "installed",
+        spec,
+        expected_blender_commit="expected-commit",
+        expected_python_series="3.13",
+    )
+    assert manifest["format"] == 1
+    assert manifest["release_tag"] == spec.release_tag
+
+    changed = json.loads(artifacts.manifest.read_text())
+    changed["format"] = 2
+    artifacts.manifest.write_text(json.dumps(changed))
+    with pytest.raises(ValueError, match="format"):
+        verify_and_extract_bundle(
+            artifacts.archive,
+            artifacts.manifest,
+            artifacts.checksum,
+            tmp_path / "again",
+            spec,
+            expected_blender_commit="expected-commit",
+            expected_python_series="3.13",
+        )
+
+
+def test_zstd_decoder_large_stderr_does_not_deadlock(tmp_path: Path):
+    source = tmp_path / "linux_arm64"
+    source.mkdir()
+    (source / "value").write_text("original")
+    spec = BundleSpec(blender_version="5.2.0", revision=1)
+    artifacts = create_bundle(source, tmp_path / "dist", spec)
+    real_zstd = shutil.which("zstd")
+    assert real_zstd is not None
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    wrapper = wrapper_dir / "zstd"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        "dd if=/dev/zero bs=1048576 count=1 1>&2 2>/dev/null\n"
+        f'exec "{real_zstd}" "$@"\n'
+    )
+    wrapper.chmod(0o755)
+    code = (
+        "from pathlib import Path; "
+        "from buildbpy.arm64_deps import BundleSpec, verify_and_extract_bundle; "
+        f"verify_and_extract_bundle(Path({str(artifacts.archive)!r}), "
+        f"Path({str(artifacts.manifest)!r}), Path({str(artifacts.checksum)!r}), "
+        f"Path({str(tmp_path / 'installed')!r}), BundleSpec('5.2.0'))"
+    )
+    environment = {**os.environ, "PATH": f"{wrapper_dir}:{os.environ['PATH']}"}
+
+    subprocess.run([sys.executable, "-c", code], env=environment, check=True, timeout=10)
+
+
+def test_tag_build_resolves_checked_out_head_for_dependency_provenance(tmp_path: Path):
+    builder = BlenderBuilder.__new__(BlenderBuilder)
+    builder.blender_repo_dir = tmp_path / "blender"
+    builder.blender_repo_dir.mkdir()
+    builder.root_dir = tmp_path
+    builder.os_type = "Linux"
+    builder.lib_dir = tmp_path / "lib"
+    checkout = SimpleNamespace(
+        checkout=lambda tag: None,
+        set_version=lambda commit, tag: None,
+        major_version="5.2",
+        minor_version="5.2.0",
+        release_cycle="release",
+    )
+    captured = {}
+
+    def setup_strategies(
+        os_type, major_version, minor_version, release_cycle, commit_hash, root, repo
+    ):
+        captured["commit_hash"] = commit_hash
+        builder.os_strategy = SimpleNamespace(
+            build_dir=tmp_path / "build",
+            make_command="make",
+            setup_build_environment=lambda: None,
+            set_cmake_directives=lambda: None,
+            prepare_bpy_build=lambda: None,
+            get_bpy_build_command=lambda: "make bpy",
+            run_command=lambda command, cwd: None,
+            build_wheel_dir=tmp_path / "wheel",
+        )
+
+    builder.setup_strategies = setup_strategies
+    builder.generate_stubs = lambda commit: None
+    builder.build_and_manage_wheel = lambda *args: None
+
+    with (
+        patch("buildbpy.main.TagCheckoutStrategy", return_value=checkout),
+        patch(
+            "buildbpy.main.subprocess.check_output",
+            return_value="resolved-head-commit\n",
+        ),
+    ):
+        assert builder.main(
+            "v5.2.0", "", False, False, False, False, "", "", False
+        )
+
+    assert captured["commit_hash"] == "resolved-head-commit"

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -585,6 +585,8 @@ def test_linux_arm64_falls_back_when_bundle_decoder_is_unavailable(
 def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
     workflow = (REPO_ROOT / ".github/workflows/build_linux_arm64.yml").read_text()
 
+    assert "- name: Build and install bpy" in workflow
+    assert "- name: Build and publish bpy" not in workflow
     assert "TAG: ${{ inputs.tag || github.event.inputs.tag }}" in workflow
     assert (
         "PYTHON_VERSION: ${{ inputs.python_version || github.event.inputs.python_version }}"

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -477,6 +477,10 @@ def test_arm64_workflow_validates_exact_tag_and_publishes_immutable_release():
     verify_offset = workflow.index("- name: Verify wheel architecture and import")
     assert "--publish" not in workflow[:verify_offset]
     assert workflow.index("- name: Publish verified bpy wheel") > verify_offset
+    assert "- name: Check existing ARM64 dependency release" in workflow
+    assert "id: deps_release" in workflow
+    assert workflow.count("steps.deps_release.outputs.exists != 'true'") == 2
+    assert "already exists and is immutable" not in workflow
 
 
 def test_download_release_bundle_rejects_non_object_api_payload(tmp_path: Path):

--- a/tests/test_arm64_deps_bundle.py
+++ b/tests/test_arm64_deps_bundle.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
 import tarfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
 import httpx
@@ -13,6 +14,7 @@ import pytest
 
 from buildbpy.arm64_deps import (
     BundleSpec,
+    _open_zstd_tar,
     configure_arm64_wayland_lib64,
     create_bundle,
     disable_arm64_osl_optix,
@@ -23,6 +25,23 @@ from buildbpy.arm64_deps import (
 from buildbpy.main import BlenderBuilder, LinuxOSStrategy, ReleaseVersionCycleStrategy
 
 
+def _arm64_bundle_tools_available() -> bool:
+    if platform.system() != "Linux" or not shutil.which("tar") or not shutil.which("zstd"):
+        return False
+    result = subprocess.run(
+        ["tar", "--help"], capture_output=True, text=True, check=False
+    )
+    return result.returncode == 0 and all(
+        option in result.stdout for option in ("--zstd", "--sort", "--mtime")
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _arm64_bundle_tools_available(),
+    reason="Linux ARM64 bundle tests require GNU tar with zstd support and zstd",
+)
+
+
 def test_bundle_spec_has_stable_release_names():
     spec = BundleSpec(blender_version="5.2.0", revision=1)
 
@@ -30,6 +49,38 @@ def test_bundle_spec_has_stable_release_names():
     assert spec.archive_name == "blender-5.2.0-linux-arm64-ubuntu24.04-gcc13-v1.tar.zst"
     assert spec.manifest_name == f"{spec.archive_name}.manifest.json"
     assert spec.checksum_name == f"{spec.archive_name}.sha256"
+
+
+def test_open_zstd_tar_reports_missing_decoder_and_closes_stderr(tmp_path: Path):
+    stderr_file = MagicMock()
+    with (
+        patch("buildbpy.arm64_deps.tempfile.TemporaryFile", return_value=stderr_file),
+        patch(
+            "buildbpy.arm64_deps.subprocess.Popen",
+            side_effect=FileNotFoundError("zstd"),
+        ),
+        pytest.raises(RuntimeError, match="zstd executable is required"),
+    ):
+        with _open_zstd_tar(tmp_path / "bundle.tar.zst"):
+            pass
+
+    stderr_file.close.assert_called_once()
+
+
+def test_linux_run_command_routes_updates_through_retry_handler(tmp_path: Path):
+    strategy = LinuxOSStrategy.__new__(LinuxOSStrategy)
+
+    with (
+        patch.object(strategy, "run_update_command") as run_update,
+        patch(
+            "buildbpy.main.subprocess.Popen",
+            side_effect=AssertionError("update command bypassed retry handler"),
+        ) as popen,
+    ):
+        strategy.run_command("make update", tmp_path)
+
+    run_update.assert_called_once_with("make update", tmp_path)
+    popen.assert_not_called()
 
 
 def test_arm64_osl_patch_disables_cuda_optix_only_on_arm(tmp_path: Path):
@@ -493,6 +544,10 @@ def test_build_all_includes_linux_arm64_in_aggregate_success_barrier():
     update_section = workflow.split("  update-versions:", 1)[1]
     update_needs = update_section.split("\n    if:", 1)[0]
     assert "build-for-linux-arm64" in update_needs
+    assert "EndBug/add-and-commit" not in workflow
+    assert 'git config user.name "github-actions[bot]"' in workflow
+    assert "git add -- workspace/version_info.json" in workflow
+    assert 'git push origin "HEAD:${GITHUB_REF_NAME}"' in workflow
 
 
 def test_download_release_bundle_rejects_non_object_api_payload(tmp_path: Path):


### PR DESCRIPTION
## Summary
- build Blender 5.2 `bpy` natively on Linux ARM64 with CPython 3.13 and GCC 14
- consume an immutable, checksummed ARM64 dependency-prefix release with safe extraction and native `make deps` fallback
- validate architecture, installation, `import bpy`, and the exact requested Blender version before wheel publication
- include the Linux ARM64 reusable workflow in `build_all` and gate version/index updates on its success

## Verification
- 30 local tests pass
- Python compilation, workflow YAML parsing, and diff checks pass
- local DGX Spark wheel install/import passed on native aarch64
- GitHub Actions ARM64 run 33153998261 passed using the published dependency bundle
- published wheel: `bpy-5.2.0-cp313-cp313-manylinux_2_39_aarch64.whl`
- final specification and security/correctness reviews returned zero findings

## Compatibility
- existing Linux AMD64, macOS, and Windows jobs are unchanged
- ARM64-specific compiler and dependency behavior is scoped to native Linux ARM64
